### PR TITLE
Tanstack Form custom component typings

### DIFF
--- a/src/registry/components/ui/form-tanstack.tsx
+++ b/src/registry/components/ui/form-tanstack.tsx
@@ -128,23 +128,35 @@ function FieldMessage({ className, ...props }: React.ComponentProps<"p">) {
   );
 }
 
-const createFormHook = (
-  args?: Parameters<typeof createTanstackFormHook>[0]
-) => {
-  const formHook = createTanstackFormHook({
-    fieldComponents: {
-      ...args?.fieldComponents,
-      Label: FieldLabel,
-      Control: FieldControl,
-      Description: FieldDescription,
-      Message: FieldMessage,
-    },
-    formComponents: { ...args?.formComponents, Item: FormItem },
+function createFormHook<
+  TFieldComponents extends Record<string, ComponentType<any>> = {},
+  TFormComponents extends Record<string, ComponentType<any>> = {},
+>(args?: {
+  fieldComponents?: TFieldComponents
+  formComponents?: TFormComponents
+}) {
+  const mergedFieldComponents = {
+    Control: FieldControl,
+    Description: FieldDescription,
+    Label: FieldLabel,
+    Message: FieldMessage,
+    ...(args?.fieldComponents ?? ({} as TFieldComponents)),
+  };
+
+  const mergedFormComponents = {
+    Item: FormItem,
+    ...(args?.formComponents ?? ({} as TFormComponents)),
+  };
+
+  return createTanstackFormHook<
+    typeof mergedFieldComponents,
+    typeof mergedFormComponents
+  >({
+    fieldComponents: mergedFieldComponents,
     fieldContext,
+    formComponents: mergedFormComponents,
     formContext,
   });
-
-  return formHook;
-};
+}
 
 export { createFormHook };


### PR DESCRIPTION
Fixes custom components not being typed correctly when passed via `createFormHook`

At the moment, custom components passed to `createFormHook` are not typed. You also have to pass the two contexts even though they are not used:

```ts
import { createFormHookContexts } from '@tanstack/react-form';
import { createFormHook } from '../ui/form-tanstack';
import { MyCustomInput } from '../components/my-custom-input';

const { fieldContext, formContext } = createFormHookContexts();

const {
  useAppForm,
} = createFormHook({
  fieldComponents: {
    MyCustomInput,
  },
  fieldContext,
  formComponents: {},
  formContext,
});
```

results in a TS error:

```
Property 'MyCustomInput' does not exist on type 'FieldApi<{ ... }, ...> & NoInfer<{ ...; }>'.ts(2339)
```

<img width="607" height="426" alt="image" src="https://github.com/user-attachments/assets/6644dc50-fae9-4bdf-be80-cb06a89462b7" />


This PR removes the need to pass the contexts and allows you to **optionally** pass addition field and/or form components with correct typings. 

Example:

```ts
import { createFormHook } from '../ui/form-tanstack';
import { MyCustomInput } from '../components/my-custom-input';

const {
  useAppForm,
} = createFormHook({
  fieldComponents: {
    MyCustomInput,
  },
});
```

<img width="607" height="426" alt="image" src="https://github.com/user-attachments/assets/299b55c3-a3c7-45cd-8e26-7c366c46d225" />

